### PR TITLE
Document requirement for go 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Have a look at the unit tests for usage examples:
 
 ## Prerequisites
 
+-   Go version 1.19 or later
 -   `traceroute` (for testing)
 -   `libpcap` (for compiling BPF filter expressions of packet tracing feature)
 


### PR DESCRIPTION
It appears that Gont requires at least Go 1.19:

    # github.com/stv0g/gont/pkg
    pkg/capture.go:90:15: undefined: atomic.Uint64
    note: module requires Go 1.19
    make: *** [Makefile:8: gontc] Error 2

Add this to the Prerequisites section of the README.
