### PR TITLE
Fix list of tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Have a look at our **[slide set](https://stv0g.github.io/gont/)** to get you sta
 
 Have a look at the unit tests for usage examples:
 
--   [Simple](pkg/simple_test.go)
--   [Run](pkg/node_test.go)
+-   [Ping](pkg/ping_test.go)
+-   [Run](pkg/run_test.go)
 -   [NAT](pkg/nat_test.go)
 -   [Switch](pkg/switch_test.go)
 -   [Links](pkg/link_test.go)


### PR DESCRIPTION
The "Examples" section of the README includes links to tests that no longer
exist.

- pkg/simple_test.go was renamed to pkg/ping_test.go in c3c5ffb
- pkg/node_test.go was renamed to pkg/run_test.go in c8f6a15
